### PR TITLE
On fullfiled and on rejected handler should execute asynchronously

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,4 +2,3 @@ require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 task :default => :spec
-

--- a/eventkit-promise.gemspec
+++ b/eventkit-promise.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.2.0"
+  spec.add_development_dependency "eventkit-eventloop", "~> 0.1.0"
 end

--- a/lib/eventkit/task_scheduler.rb
+++ b/lib/eventkit/task_scheduler.rb
@@ -1,0 +1,10 @@
+module Eventkit
+  class TaskScheduler
+    def schedule_execution(&handler)
+      fail NotImplementedError, <<-DOC
+Implement #schedule_execution in your class to schedule
+the execution of on_fullfiled and on_rejected handlers
+DOC
+    end
+  end
+end

--- a/spec/eventkit/promise_spec.rb
+++ b/spec/eventkit/promise_spec.rb
@@ -1,111 +1,180 @@
 require 'eventkit/promise'
+require 'eventkit/event_loop'
+require 'eventkit/task_scheduler'
 
 module Eventkit
   RSpec.describe Promise do
-    let(:promise) { Promise.new }
+
+    class NextTickScheduler < Eventkit::TaskScheduler
+      def initialize(event_loop)
+        @event_loop = event_loop
+      end
+
+      def schedule_execution(&handler)
+        @event_loop.on_next_tick(&handler)
+      end
+    end
+
+    let(:event_loop) {
+      EventLoop.new
+    }
+
+    let(:task_scheduler) {
+       NextTickScheduler.new(event_loop)
+    }
+
+    let(:promise) {
+      Promise.new(task_scheduler)
+    }
+
+    def start_event_loop
+      event_loop.register_timer(run_in: 0.1) {
+        event_loop.stop
+      }
+      event_loop.start
+    end
+
+    it 'accepts a block when initialized' do
+      promise = Promise.new(task_scheduler) { |p|
+        p.resolve(:foo)
+      }
+
+      expect { |block|
+        promise.then(block)
+
+        start_event_loop
+      }.to yield_with_args(:foo)
+    end
 
     it 'executes on fullfiled handlers when resolved' do
-      expect do |block|
+      expect { |block|
         promise.on_fullfiled(&block)
         promise.on_fullfiled(&block)
         promise.on_fullfiled(&block)
         promise.resolve(:foo)
-      end.to yield_successive_args(:foo, :foo, :foo)
+
+        start_event_loop
+      }.to yield_successive_args(:foo, :foo, :foo)
     end
 
     it 'executes on fullfiled handlers after resolved' do
-      expect do |block|
+      expect { |block|
         promise.resolve(:foo)
         promise.on_fullfiled(&block)
-      end.to yield_successive_args(:foo)
+
+        start_event_loop
+      }.to yield_with_args(:foo)
     end
 
     it 'does not execute on fullfiled handler when resolved with a pending promise' do
-      promise_b = Promise.new
-      expect do |block|
+      promise_b = Promise.new(task_scheduler)
+      expect { |block|
         promise.resolve(promise_b)
         promise.on_fullfiled(&block)
-      end.to_not yield_control.once
+
+        start_event_loop
+      }.to_not yield_control.once
     end
 
     it 'only executes on fullfiled handlers once even when resolved multiple times' do
-      expect do |block|
+      expect { |block|
         promise.on_fullfiled(&block)
         promise.resolve(:foo)
         promise.resolve(:foo)
-      end.to yield_control.once
+
+        start_event_loop
+      }.to yield_control.once
     end
 
     it 'executes on fullfiled handlers in the same order as the originating calls' do
-      expect do |block|
+      expect { |block|
         promise.on_fullfiled { block.to_proc.call(1) }
         promise.on_fullfiled { block.to_proc.call(2) }
         promise.on_fullfiled { block.to_proc.call(3) }
         promise.resolve(:foo)
-      end.to yield_successive_args(1, 2, 3)
+
+        start_event_loop
+      }.to yield_successive_args(1, 2, 3)
     end
 
     it 'executes on rejected handlers when rejected' do
-      expect do |block|
+      expect { |block|
         promise.on_rejected(&block)
         promise.on_rejected(&block)
         promise.on_rejected(&block)
         promise.reject(:error)
-      end.to yield_successive_args(:error, :error, :error)
+
+        start_event_loop
+      }.to yield_successive_args(:error, :error, :error)
     end
 
     it 'only executes on rejected handlers once even when rejected multiple times' do
-      expect do |block|
+      expect { |block|
         promise.on_rejected(&block)
         promise.reject(:error)
         promise.reject(:error)
-      end.to yield_control.once
+
+        start_event_loop
+      }.to yield_control.once
     end
 
     it 'executes on rejected handlers in the same order as the originating calls' do
-      expect do |block|
+      expect { |block|
         promise.on_rejected { block.to_proc.call(1) }
         promise.on_rejected { block.to_proc.call(2) }
         promise.on_rejected { block.to_proc.call(3) }
+
         promise.reject(:error)
-      end.to yield_successive_args(1, 2, 3)
+
+        start_event_loop
+      }.to yield_successive_args(1, 2, 3)
     end
 
     it 'executes on rejected handlers when it has been already rejected' do
-      expect do |block|
+      expect { |block|
         promise.reject(:error)
         promise.on_rejected(&block)
-      end.to yield_successive_args(:error)
+
+        start_event_loop
+      }.to yield_with_args(:error)
     end
 
     it 'does not execute on fullfiled handlers if it has not been fullfiled' do
-      expect do |block|
+      expect { |block|
         promise.on_fullfiled(&block)
-      end.to_not yield_with_args(:error)
+
+        start_event_loop
+      }.to_not yield_with_args(:error)
     end
 
     it 'does not execute on rejected handlers if it has not been rejected' do
-      expect do |block|
+      expect { |block|
         promise.on_rejected(&block)
-      end.to_not yield_with_args(:error)
+
+        start_event_loop
+      }.to_not yield_with_args(:error)
     end
 
     it 'can not be rejected once it has been fulfilled' do
-      expect do |block|
+      expect { |block|
         promise.on_fullfiled(&block)
         promise.resolve(:foo)
         promise.on_rejected(&block)
         promise.reject(:error)
-      end.to yield_successive_args(:foo)
+
+        start_event_loop
+      }.to yield_with_args(:foo)
     end
 
     it 'can not be fullfiled once it has been rejected' do
-      expect do |block|
+      expect { |block|
         promise.on_rejected(&block)
         promise.on_fullfiled(&block)
         promise.reject(:error)
         promise.resolve(:foo)
-      end.to yield_successive_args(:error)
+
+        start_event_loop
+      }.to yield_with_args(:error)
     end
 
     describe '#on_fullfiled' do
@@ -122,6 +191,8 @@ module Eventkit
           }
 
           promise.resolve(1)
+
+          start_event_loop
         }.to yield_successive_args(2, 7)
       end
     end
@@ -140,35 +211,43 @@ module Eventkit
           }
 
           promise.reject(1)
+
+          start_event_loop
         }.to yield_successive_args(2, 7)
       end
     end
 
     describe '#then' do
       it 'adds on fullfiled handlers' do
-        expect do |block|
+        expect { |block|
           promise.then(block)
           promise.resolve(:foo)
-        end.to yield_with_args(:foo)
+
+          start_event_loop
+        }.to yield_with_args(:foo)
       end
 
       it 'adds on rejected handlers' do
-        expect do |block|
+        expect { |block|
           promise.then(nil, block)
           promise.reject(:error)
-        end.to yield_with_args(:error)
+
+          start_event_loop
+        }.to yield_with_args(:error)
       end
 
       it 'does not require both on fullfiled and on rejected handlers' do
-        expect do |block|
+        expect { |block|
           promise.then(nil, block)
           promise.then(block)
           promise.reject(:error)
-        end.to yield_with_args(:error)
+
+          start_event_loop
+        }.to yield_with_args(:error)
       end
 
       it 'pipelines the value from on fullfiled to the returned promise' do
-        expect do |block|
+        expect { |block|
           promise
             .then(->(value) {
                     block.to_proc.call(value + 1)
@@ -182,12 +261,15 @@ module Eventkit
                     block.to_proc.call(value + 10)
                     value + 10
                   })
+
           promise.resolve(1)
-        end.to yield_successive_args(2, 7, 17)
+
+          start_event_loop
+        }.to yield_successive_args(2, 7, 17)
       end
 
       it 'pipelines the value from on rejected to the returned promise' do
-        expect do |block|
+        expect { |block|
           promise
             .then(nil, ->(reason) {
                     block.to_proc.call('bar')
@@ -201,8 +283,11 @@ module Eventkit
                     block.to_proc.call('zoo')
                     'zoo'
                   })
+
           promise.reject('foo')
-        end.to yield_successive_args('bar', 'baz', 'zoo')
+
+          start_event_loop
+        }.to yield_successive_args('bar', 'baz', 'zoo')
       end
 
       it 'rejects the returned promise when on fullfiled throws an exception' do
@@ -210,8 +295,11 @@ module Eventkit
 
         promise.resolve('foobar')
 
-        expect(promise_b).to be_rejected
-        expect(promise_b.reason).to be_an_instance_of(ArgumentError)
+        expect { |block|
+          promise_b.on_rejected(&block)
+
+          start_event_loop
+        }.to yield_with_args(an_instance_of(ArgumentError))
       end
 
       it 'rejects the returned promise when on rejected throws an exception' do
@@ -221,8 +309,11 @@ module Eventkit
 
         promise.resolve('foobar')
 
-        expect(promise_b).to be_rejected
-        expect(promise_b.reason).to be_an_instance_of(NoMethodError)
+        expect { |block|
+          promise_b.on_rejected(&block)
+
+          start_event_loop
+        }.to yield_with_args(an_instance_of(NoMethodError))
       end
 
       it 'fullfills the returned promise with the same value when on fullfiled is not a function' do
@@ -230,7 +321,11 @@ module Eventkit
 
         promise.resolve(:foo)
 
-        expect(promise_b.value).to eq(:foo)
+        expect { |block|
+          promise_b.on_fullfiled(&block)
+
+          start_event_loop
+        }.to yield_with_args(:foo)
       end
 
       it 'rejects the returned promise with the same reason when on rejected is not a function' do
@@ -238,7 +333,11 @@ module Eventkit
 
         promise.reject(:error)
 
-        expect(promise_b.reason).to eq(:error)
+        expect { |block|
+          promise_b.on_rejected(&block)
+
+          start_event_loop
+        }.to yield_with_args(:error)
       end
     end
 
@@ -248,85 +347,254 @@ module Eventkit
       end
 
       it 'adopts the given promise state when resolved with a promise'do
-        promise_a = Promise.new
-        promise_b = Promise.new
+        promise_a = Promise.new(task_scheduler)
+        promise_b = Promise.new(task_scheduler)
 
-        expect do |block|
+        expect { |block|
           promise_a.on_fullfiled(&block)
           promise_a.resolve(promise_b)
           promise_b.resolve(:foobar)
-        end.to yield_with_args(:foobar)
 
-        promise_a = Promise.new
-        promise_b = Promise.new
+          start_event_loop
+        }.to yield_with_args(:foobar)
 
-        expect do |block|
+        promise_a = Promise.new(task_scheduler)
+        promise_b = Promise.new(task_scheduler)
+
+        expect { |block|
           promise_a.on_rejected(&block)
           promise_a.resolve(promise_b)
           promise_b.reject(:error)
-        end.to yield_with_args(:error)
+
+          start_event_loop
+        }.to yield_with_args(:error)
       end
 
       it 'remains pending until the other promise is resolved' do
-        promise_a = Promise.new
-        promise_b = Promise.new
+        promise_a = Promise.new(task_scheduler)
+        promise_b = Promise.new(task_scheduler)
 
         promise_a.resolve(promise_b)
         promise_a.resolve(:foo)
 
         expect(promise_a).to be_pending
-        expect(promise_a.value).to be_nil
 
         promise_b.resolve(:bar)
 
+        start_event_loop
+
         expect(promise_a).to be_resolved
-        expect(promise_a.value).to eq(:bar)
       end
 
       it 'runs the resolution procedure when resolved with a promise and that promise is resolved' do
-        promise_b = Promise.new
+        promise_a = Promise.new(task_scheduler)
+        promise_b = Promise.new(task_scheduler)
 
-        promise.resolve(promise_b)
+        promise_a.resolve(promise_b)
 
-        promise_b.resolve(:foo)
+        expect { |block|
+          promise_b.then(block)
 
-        expect(promise_b.value).to eq(:foo)
-        expect(promise.value).to eq(:foo)
+          promise_a.then(block)
+
+          promise_b.resolve(:foo)
+
+          start_event_loop
+        }.to yield_successive_args(:foo, :foo)
       end
 
       it 'rejects the promise when resolved with a promise and that promise is rejected' do
-        promise_b = Promise.new
+        promise_a = Promise.new(task_scheduler)
+        promise_b = Promise.new(task_scheduler)
 
-        promise.resolve(promise_b)
+        promise_a.resolve(promise_b)
 
-        promise_b.reject(:error)
+        expect { |block|
+          promise_b.on_rejected(&block)
 
-        expect(promise.reason).to eq(:error)
-        expect(promise_b.reason).to eq(:error)
+          promise_a.on_rejected(&block)
 
-        expect(promise).to be_rejected
-        expect(promise_b).to be_rejected
+          promise_b.reject(:error)
+
+          start_event_loop
+        }.to yield_successive_args(:error, :error)
       end
 
       it 'rejects the promise if calling then throws an exception' do
-        promise_b = Promise.new
+        promise_a = Promise.new(task_scheduler)
+        promise_b = Promise.new(task_scheduler)
 
         allow(promise_b).to receive(:then).and_raise(NoMethodError)
 
-        promise.resolve(promise_b)
+        promise_a.resolve(promise_b)
 
-        expect(promise).to be_rejected
-        expect(promise.reason).to be_an_instance_of(NoMethodError)
+        expect { |block|
+          promise_a.on_rejected(&block)
+
+          start_event_loop
+        }.to yield_successive_args(an_instance_of(NoMethodError))
+      end
+    end
+
+    describe 'clean-stack execution ordering tests (fulfillment case)' do
+      specify 'when on_fullfiled is added immediately before the promise is fulfilled' do
+        on_fullfiled_finished = false
+
+        promise.then(->(_) { on_fullfiled_finished = true })
+
+        promise.resolve(:foobar)
+
+        expect(on_fullfiled_finished).to be_falsy
       end
 
-      it 'accepts a block when initialized' do
-        promise = Promise.new do |p|
-          p.resolve('foobar')
-        end
+      specify 'when on fullfiled is added immediately after the promise is fullfiled' do
+        on_fullfiled_finished = false
 
-        expect(promise.value).to eq('foobar')
+        promise.resolve(:foobar)
+
+        promise.then(->(_) { on_fullfiled_finished = true })
+
+        expect(on_fullfiled_finished).to be_falsy
+      end
+
+      specify 'when on fullfiled is added inside another on fullfiled' do
+        promise = Promise.new(task_scheduler)
+        on_fullfiled_finished = false
+
+        expect { |block|
+          promise.then(->(v) {
+                         promise.then(->(v) {
+                                        block.to_proc.call(on_fullfiled_finished)
+                                      })
+                         on_fullfiled_finished = true
+                       })
+
+          promise.resolve(:foo)
+
+          start_event_loop
+        }.to yield_with_args(true)
+      end
+
+      specify 'when on fullfiled is added inside on rejected' do
+        promise_a = Promise.new(task_scheduler)
+        promise_b = Promise.new(task_scheduler)
+        on_rejected_finished = false
+
+        expect { |block|
+          promise_a.then(nil, ->(v) {
+                           promise_b.then(->(v) {
+                                            block.to_proc.call(on_rejected_finished)
+                                          })
+                           on_rejected_finished = true
+                         })
+
+          promise_a.reject(:foo)
+          promise_b.resolve(:bar)
+
+          start_event_loop
+        }.to yield_with_args(true)
+      end
+
+      specify 'when the promise is fullfiled asynchronously' do
+        on_fullfiled_finished = false
+
+        expect { |block|
+          event_loop.register_timer(run_in: 0.1) {
+            on_fullfiled_finished = true
+            promise.resolve(:foo)
+          }
+
+          event_loop.register_timer(run_in: 0.2) {
+            event_loop.stop
+          }
+
+          promise.then(->(_) { block.to_proc.call(on_fullfiled_finished) })
+
+          event_loop.start
+        }.to yield_with_args(true)
+      end
+    end
+
+    describe 'clean-stack execution ordering tests (rejected case)' do
+      specify 'when on rejected is added immediately before the promise is rejected' do
+        on_rejected_finished = false
+
+        promise.on_rejected(&->(_) { on_rejected_finished = true })
+
+        promise.reject(:foobar)
+
+        expect(on_rejected_finished).to be_falsy
+      end
+
+      specify 'when on rejected is added immediately after the promise is rejected' do
+        on_rejected_finished = false
+
+        promise.reject(:foobar)
+
+        promise.then(->(_) { on_rejected_finished = true })
+
+        expect(on_rejected_finished).to be_falsy
+      end
+
+      specify 'when on rejected is added inside on fullfiled' do
+        promise_a = Promise.new(task_scheduler)
+        promise_b = Promise.new(task_scheduler)
+        on_rejected_finished = false
+
+        expect { |block|
+          promise_a.then(->(v) {
+                           promise_b.on_rejected(&->(v) {
+                                                   block.to_proc.call(on_rejected_finished)
+                                                 })
+                           on_rejected_finished = true
+                         })
+
+          promise_a.resolve(:foo)
+          promise_b.reject(:bar)
+
+          start_event_loop
+        }.to yield_with_args(true)
+      end
+
+      specify 'when on rejected is added inside on rejected' do
+        promise_a = Promise.new(task_scheduler)
+        promise_b = Promise.new(task_scheduler)
+        on_rejected_finished = false
+
+
+        expect { |block|
+          promise_a.on_rejected(&->(v) {
+                                  promise_b.on_rejected(&->(v) {
+                                                          block.to_proc.call(on_rejected_finished)
+                                                        })
+                                  on_rejected_finished = true
+                                })
+
+          promise_a.reject(:foo)
+          promise_b.reject(:bar)
+
+          start_event_loop
+        }.to yield_with_args(true)
+      end
+
+      specify 'when the promise is rejected asynchronously' do
+        on_rejected_finished = false
+
+        expect { |block|
+          event_loop.register_timer(run_in: 0.1) {
+            on_rejected_finished = true
+            promise.reject(:error)
+          }
+
+          event_loop.register_timer(run_in: 0.2) {
+            event_loop.stop
+          }
+
+          promise.on_rejected(&->(_) { block.to_proc.call(on_rejected_finished) })
+
+          event_loop.start
+        }.to yield_with_args(true)
       end
     end
   end
 end
-


### PR DESCRIPTION
Previously, handlers were executed immediately after resolving or
rejecting a promise. So, you would have different behaviour depending
on when you added a handler. This means that we were not fully compliant
with point 2.2.4 of the Promises A+ spec.

From now on, a promise takes a Task Scheduler object that should implement a
`#schedule_execution` method. This method should take care of providing
the execution context for handlers.

We've also removed readers for value and reason, as we should encourage
using handlers when trying to read the value of a promise.
